### PR TITLE
Import obj files into Unity Aov

### DIFF
--- a/Unity AOV/environment.py
+++ b/Unity AOV/environment.py
@@ -7,267 +7,268 @@ from . import files
 from .files import File, ObjectReader
 from .enums import FileType
 from .helpers import ImportHelper
-from .streams import EndianBinaryReader
+# from .streams import EndianBinaryReader
 from .files import SerializedFile
+from .streams.EndianBinaryReader import EndianBinaryReader as EBR
 
 reSplit = re.compile(r"(.*?([^\/\\]+?))\.split\d+")
 
 
 class Environment:
-    files: dict
-    cabs: dict
-    path: str
+	files: dict
+	cabs: dict
+	path: str
 
-    def __init__(self, *args):
-        self.files = {}
-        self.cabs = {}
-        self.path = None
-        self.out_path = os.path.join(os.getcwd(), "output")
+	def __init__(self, *args):
+		self.files = {}
+		self.cabs = {}
+		self.path = None
+		self.out_path = os.path.join(os.getcwd(), "output")
 
-        if args:
-            for arg in args:
-                if isinstance(arg, str):
-                    if os.path.isfile(arg):
-                        if os.path.splitext(arg)[-1] in [".apk", ".zip"]:
-                            self.load_zip_file(arg)
-                        else:
-                            self.path = os.path.dirname(arg)
-                            if reSplit.match(arg):
-                                self.load_files([arg])
-                            else:
-                                self.load_file(arg)
-                    elif os.path.isdir(arg):
-                        self.path = arg
-                        self.load_folder(arg)
-                else:
-                    self.path = None
-                    self.load_file(file=arg)
+		if args:
+			for arg in args:
+				if isinstance(arg, str):
+					if os.path.isfile(arg):
+						if os.path.splitext(arg)[-1] in [".apk", ".zip"]:
+							self.load_zip_file(arg)
+						else:
+							self.path = os.path.dirname(arg)
+							if reSplit.match(arg):
+								self.load_files([arg])
+							else:
+								self.load_file(arg)
+					elif os.path.isdir(arg):
+						self.path = arg
+						self.load_folder(arg)
+				else:
+					self.path = None
+					self.load_file(file=arg)
 
-        if len(self.files) == 1:
-            self.file = list(self.files.values())[0]
+		if len(self.files) == 1:
+			self.file = list(self.files.values())[0]
 
-        if self.path == "":
-            self.path = os.getcwd()
+		if self.path == "":
+			self.path = os.getcwd()
 
-    def load_files(self, files: List[str]):
-        """Loads all files (list) into the Environment and merges .split files for common usage."""
-        self.load_assets(files, lambda x: open(x, "rb"))
+	def load_files(self, files: List[str]):
+		"""Loads all files (list) into the Environment and merges .split files for common usage."""
+		self.load_assets(files, lambda x: open(x, "rb"))
 
-    def load_folder(self, path: str):
-        """Loads all files in the given path and its subdirs into the Environment."""
-        self.load_files(
-            [
-                os.path.join(root, f)
-                for root, dirs, files in os.walk(path)
-                for f in files
-            ]
-        )
+	def load_folder(self, path: str):
+		"""Loads all files in the given path and its subdirs into the Environment."""
+		self.load_files(
+			[
+				os.path.join(root, f)
+				for root, dirs, files in os.walk(path)
+				for f in files
+			]
+		)
 
-    def load(self, files: list):
-        """Loads all files into the Environment."""
-        self.files.update(
-            {
-                os.path.basename(f): self.load_file(open(f, "rb"), self, f)
-                for f in files
-                if os.path.exists(f)
-            }
-        )
+	def load(self, files: list):
+		"""Loads all files into the Environment."""
+		self.files.update(
+			{
+				os.path.basename(f): self.load_file(open(f, "rb"), self, f)
+				for f in files
+				if os.path.exists(f)
+			}
+		)
 
-    def load_file(
-        self,
-        file: Union[io.IOBase, str],
-        parent: Union["Environment", File] = None,
-        name: str = None,
-    ):
-        if not parent:
-            parent = self
-        if isinstance(file, str):
-            split_match = reSplit.match(file)
-            if split_match:
-                basepath, basename = split_match.groups()
-                file = []
-                for i in range(0, 999):
-                    item = f"{basepath}.split{i}"
-                    if item in files:
-                        with open(item, "rb") as f:
-                            file.append(f.read())
-                    elif i:
-                        break
-                name = basepath
-                file = b"".join(file)
-            else:
-                name = file
-                file = open(file, "rb")
+	def load_file(
+		self,
+		file: Union[io.IOBase, str],
+		parent: Union["Environment", File] = None,
+		name: str = None,
+	):
+		if not parent:
+			parent = self
+		if isinstance(file, str):
+			split_match = reSplit.match(file)
+			if split_match:
+				basepath, basename = split_match.groups()
+				file = []
+				for i in range(0, 999):
+					item = f"{basepath}.split{i}"
+					if item in files:
+						with open(item, "rb") as f:
+							file.append(f.read())
+					elif i:
+						break
+				name = basepath
+				file = b"".join(file)
+			else:
+				name = file
+				file = open(file, "rb")
 
-        typ, reader = ImportHelper.check_file_type(file)
+		typ, reader = ImportHelper.check_file_type(file)
 
-        try:
-            stream_name = (
-                name
-                if name
-                else getattr(
-                    file,
-                    "name",
-                    str(file.__hash__()) if hasattr(file, "__hash__") else "",
-                )
-            )
+		try:
+			stream_name = (
+				name
+				if name
+				else getattr(
+					file,
+					"name",
+					str(file.__hash__()) if hasattr(file, "__hash__") else "",
+				)
+			)
 
-            if typ == FileType.AssetsFile:
-                f = files.SerializedFile(reader, parent, name=stream_name)
-                self.register_cab(stream_name, f)
-            elif typ == FileType.BundleFile:
-                f = files.BundleFile(reader, parent, name=stream_name)
-            elif typ == FileType.WebFile:
-                f = files.WebFile(reader, parent, name=stream_name)
-            elif typ == FileType.ZIP:
-                f = self.load_zip_file(file)
-            elif typ == FileType.ResourceFile:
-                f = EndianBinaryReader(file)
-                self.register_cab(stream_name, f)
+			if typ == FileType.AssetsFile:
+				f = files.SerializedFile(reader, parent, name=stream_name)
+				self.register_cab(stream_name, f)
+			elif typ == FileType.BundleFile:
+				f = files.BundleFile(reader, parent, name=stream_name)
+			elif typ == FileType.WebFile:
+				f = files.WebFile(reader, parent, name=stream_name)
+			elif typ == FileType.ZIP:
+				f = self.load_zip_file(file)
+			elif typ == FileType.ResourceFile:
+				f = EBR(file)
+				self.register_cab(stream_name, f)
 
-            self.files[stream_name] = f
-            return f
-        except Exception as e:
-            # just to be sure
-            # cuz the SerializedFile detection isn't perfect
-            print("Error loading, reverting to EndianBinaryReader:\n", str(e))
-            return EndianBinaryReader(file)
+			self.files[stream_name] = f
+			return f
+		except Exception as e:
+			# just to be sure
+			# cuz the SerializedFile detection isn't perfect
+			print("Error loading, reverting to EndianBinaryReader:\n", str(e))
+			return EBR(file)
 
-    def load_zip_file(self, value):
-        buffer = None
-        if isinstance(value, str) and os.path.exists(value):
-            buffer = open(value, "rb")
-        elif isinstance(value, (bytes, bytearray)):
-            buffer = io.BytesIO(value)
-        elif isinstance(value, (io.BufferedReader, io.BufferedIOBase)):
-            buffer = value
+	def load_zip_file(self, value):
+		buffer = None
+		if isinstance(value, str) and os.path.exists(value):
+			buffer = open(value, "rb")
+		elif isinstance(value, (bytes, bytearray)):
+			buffer = io.BytesIO(value)
+		elif isinstance(value, (io.BufferedReader, io.BufferedIOBase)):
+			buffer = value
 
-        z = ZipFile(buffer)
-        self.load_assets(z.namelist(), lambda x: z.open(x, "r"))
-        z.close()
+		z = ZipFile(buffer)
+		self.load_assets(z.namelist(), lambda x: z.open(x, "r"))
+		z.close()
 
-    def save(self, pack="none"):
-        """Saves all changed assets.
-        Mark assets as changed using `.mark_changed()`.
-        pack = "none" (default) or "lz4"
-        """
-        for f in self.files:
-            if self.files[f].is_changed:
-                with open(
-                    os.path.join(self.out_path, os.path.basename(f)), "wb"
-                ) as out:
-                    out.write(self.files[f].save(packer=pack))
+	def save(self, pack="none"):
+		"""Saves all changed assets.
+		Mark assets as changed using `.mark_changed()`.
+		pack = "none" (default) or "lz4"
+		"""
+		for f in self.files:
+			if self.files[f].is_changed:
+				with open(
+					os.path.join(self.out_path, os.path.basename(f)), "wb"
+				) as out:
+					out.write(self.files[f].save(packer=pack))
 
-    @property
-    def objects(self) -> List[ObjectReader]:
-        """Returns a list of all objects in the Environment."""
+	@property
+	def objects(self) -> List[ObjectReader]:
+		"""Returns a list of all objects in the Environment."""
 
-        def search(item):
-            ret = []
-            if not isinstance(item, Environment) and getattr(item, "objects", None):
-                # serialized file
-                return [val for val in item.objects.values()]
+		def search(item):
+			ret = []
+			if not isinstance(item, Environment) and getattr(item, "objects", None):
+				# serialized file
+				return [val for val in item.objects.values()]
 
-            elif getattr(item, "files", None):  # WebBundle and BundleFile
-                # bundle
-                for item in item.files.values():
-                    ret.extend(search(item))
-                return ret
+			elif getattr(item, "files", None):  # WebBundle and BundleFile
+				# bundle
+				for item in item.files.values():
+					ret.extend(search(item))
+				return ret
 
-            return ret
+			return ret
 
-        return search(self)
+		return search(self)
 
-    @property
-    def container(self) -> Dict[str, ObjectReader]:
-        """Returns a dictionary of all objects in the Environment."""
-        return {
-            path: obj
-            for f in self.files.values()
-            if isinstance(f, File)
-            for path, obj in f.container.items()
-        }
+	@property
+	def container(self) -> Dict[str, ObjectReader]:
+		"""Returns a dictionary of all objects in the Environment."""
+		return {
+			path: obj
+			for f in self.files.values()
+			if isinstance(f, File)
+			for path, obj in f.container.items()
+		}
 
-    @property
-    def assets(self) -> list:
-        """
-        Lists all assets / SerializedFiles within this environment.
-        """
+	@property
+	def assets(self) -> list:
+		"""
+		Lists all assets / SerializedFiles within this environment.
+		"""
 
-        def gen_all_asset_files(file, ret=[]):
-            for f in getattr(file, "files", {}).values():
-                if isinstance(f, SerializedFile):
-                    ret.append(f)
-                else:
-                    gen_all_asset_files(f, ret)
-            return ret
+		def gen_all_asset_files(file, ret=[]):
+			for f in getattr(file, "files", {}).values():
+				if isinstance(f, SerializedFile):
+					ret.append(f)
+				else:
+					gen_all_asset_files(f, ret)
+			return ret
 
-        return gen_all_asset_files(self)
+		return gen_all_asset_files(self)
 
-    def get(self, key: str, default=None):
-        return getattr(self, key, default)
+	def get(self, key: str, default=None):
+		return getattr(self, key, default)
 
-    def register_cab(self, name: str, item: File) -> None:
-        """
-        Registers a cab file.
+	def register_cab(self, name: str, item: File) -> None:
+		"""
+		Registers a cab file.
 
-        Parameters
-        ----------
-        name : str
-            The name of the cab file.
-        item : File
-            The file to register.
-        """
-        self.cabs[os.path.basename(name.lower())] = item
+		Parameters
+		----------
+		name : str
+			The name of the cab file.
+		item : File
+			The file to register.
+		"""
+		self.cabs[os.path.basename(name.lower())] = item
 
-    def get_cab(self, name: str) -> File:
-        """
-        Returns the cab file with the given name.
+	def get_cab(self, name: str) -> File:
+		"""
+		Returns the cab file with the given name.
 
-        Parameters
-        ----------
-        name : str
-            The name of the cab file.
+		Parameters
+		----------
+		name : str
+			The name of the cab file.
 
-        Returns
-        -------
-        File
-            The cab file.
-        """
-        return self.cabs.get(os.path.basename(name.lower()), None)
+		Returns
+		-------
+		File
+			The cab file.
+		"""
+		return self.cabs.get(os.path.basename(name.lower()), None)
 
-    def load_assets(self, assets: List[str], open_f: Callable[[str], io.IOBase]):
-        """
-        Load all assets from a list of files via the given open_f function.
+	def load_assets(self, assets: List[str], open_f: Callable[[str], io.IOBase]):
+		"""
+		Load all assets from a list of files via the given open_f function.
 
-        Parameters
-        ----------
-        assets : List[str]
-            List of files to load.
-        open_f : Callable[[str], io.IOBase]
-            Function to open the files.
-            The function takes a file path and returns an io.IOBase object.
-        """
-        split_files = []
-        for path in assets:
-            splitMatch = reSplit.match(path)
-            if splitMatch:
-                basepath, basename = splitMatch.groups()
+		Parameters
+		----------
+		assets : List[str]
+			List of files to load.
+		open_f : Callable[[str], io.IOBase]
+			Function to open the files.
+			The function takes a file path and returns an io.IOBase object.
+		"""
+		split_files = []
+		for path in assets:
+			splitMatch = reSplit.match(path)
+			if splitMatch:
+				basepath, basename = splitMatch.groups()
 
-                if basepath in split_files:
-                    continue
+				if basepath in split_files:
+					continue
 
-                split_files.append(basepath)
-                data = []
-                for i in range(0, 999):
-                    item = f"{basepath}.split{i}"
-                    if item in assets:
-                        with open_f(item) as f:
-                            data.append(f.read())
-                    elif i:
-                        break
-                data = b"".join(data)
-                path = basepath
-            else:
-                data = open_f(path).read()
-            self.load_file(data, name=path)
+				split_files.append(basepath)
+				data = []
+				for i in range(0, 999):
+					item = f"{basepath}.split{i}"
+					if item in assets:
+						with open_f(item) as f:
+							data.append(f.read())
+					elif i:
+						break
+				data = b"".join(data)
+				path = basepath
+			else:
+				data = open_f(path).read()
+			self.load_file(data, name=path)

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -381,7 +381,18 @@ def _rebuild_vertex_data_modern(m, verts: List[Tuple[float, float, float]], norm
 		channels[4].offset = 24
 		channels[4].dimension = 2
 		vd.m_Channels = channels
-		vd.m_Streams = {0: object()}
+		# Set stream 0 metadata
+		try:
+			StreamInfo = getattr(MeshMod, 'StreamInfo')
+			si0 = object.__new__(StreamInfo)
+			si0.channelMask = (1 << 0) | (1 << 1) | (1 << 4)
+			si0.offset = 0
+			si0.stride = stride
+			si0.dividerOp = 0
+			si0.frequency = 0
+			vd.m_Streams = {0: si0}
+		except Exception:
+			vd.m_Streams = {0: object()}
 		vd.m_DataSize = bytes(buf)
 		# Clear compressed mesh to avoid overrides
 		cm = getattr(m, 'm_CompressedMesh', None)

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -294,8 +294,11 @@ def try_replace_mesh_in_assets(assets_path: str, obj_mesh: ObjMesh, target_name:
 				except Exception as e:
 					if debug:
 						print(f"[DEBUG] m.save() failed: {e}")
-					# fallback to typetree
-					m.save_typetree()
+					# fallback to typetree only if available
+					if hasattr(m, "save_typetree"):
+						m.save_typetree()
+					else:
+						return False, f"Mesh class doesn't support save_typetree and save() failed: {e}"
 				try:
 					m.assets_file.mark_changed()
 				except Exception:
@@ -350,11 +353,8 @@ def try_replace_mesh_in_assets(assets_path: str, obj_mesh: ObjMesh, target_name:
 		# Try save
 		try:
 			m.save()
-		except Exception:
-			try:
-				m.save_typetree()
-			except Exception as e2:
-				return False, f"Failed to save mesh data: {e2}"
+		except Exception as e:
+			return False, f"UnityPy Mesh can't be saved: {e}"
 		if out_dir:
 			up_env.out_path = out_dir
 		os.makedirs(getattr(up_env, "out_path", os.path.join(os.getcwd(), "output")), exist_ok=True)

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -343,7 +343,7 @@ def _rebuild_vertex_data_modern(m, verts: List[Tuple[float, float, float]], norm
 			nx,ny,nz = norms[i]
 			u,v = uvs[i]
 			for val in (x,y,z,nx,ny,nz,u,v):
-				buf[off:off+4] = struct.pack('>f', float(val))
+				buf[off:off+4] = struct.pack('<f', float(val))
 				off += 4
 		# Channel indices: 0=pos,1=normal,4=uv0
 		from importlib import import_module

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -324,6 +324,11 @@ def _update_submesh_and_flags(m, num_vertices: int, num_indices: int):
 			m.m_MeshCompression = 0
 		if hasattr(m, "m_StreamCompression"):
 			m.m_StreamCompression = 0
+		if hasattr(m, "m_MeshUsageFlags"):
+			try:
+				m.m_MeshUsageFlags = int(max(0, min(255, int(m.m_MeshUsageFlags))))
+			except Exception:
+				m.m_MeshUsageFlags = 0
 	except Exception:
 		pass
 

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -1,0 +1,253 @@
+import os
+import sys
+import json
+from dataclasses import dataclass
+from typing import List, Tuple, Dict, Optional
+
+# Minimal OBJ importer (no external deps)
+
+@dataclass
+class ObjMesh:
+	positions: List[Tuple[float, float, float]]
+	normals: List[Tuple[float, float, float]]
+	texcoords: List[Tuple[float, float]]
+	# Unified vertex stream after indexing by (v, vt, vn)
+	vertices: List[Tuple[float, float, float]]
+	normals_u: List[Tuple[float, float, float]]
+	uvs_u: List[Tuple[float, float]]
+	indices: List[int]
+
+
+def parse_obj(obj_path: str) -> ObjMesh:
+	"""
+	Parse a Wavefront OBJ file. Supports v/vt/vn and faces with arbitrary polygon size.
+	Faces are triangulated via fan method. Builds a unified vertex stream indexed by (v,vt,vn).
+	"""
+	positions: List[Tuple[float, float, float]] = []
+	normals: List[Tuple[float, float, float]] = []
+	texcoords: List[Tuple[float, float]] = []
+
+	# After unifying v/vt/vn tuples
+	vertex_map: Dict[Tuple[int, int, int], int] = {}
+	vertices_u: List[Tuple[float, float, float]] = []
+	normals_u: List[Tuple[float, float, float]] = []
+	uvs_u: List[Tuple[float, float]] = []
+	indices: List[int] = []
+
+	def add_vertex(vi: int, ti: int, ni: int) -> int:
+		key = (vi, ti, ni)
+		idx = vertex_map.get(key)
+		if idx is not None:
+			return idx
+		# OBJ is 1-based; allow negative indices
+		v = positions[vi - 1 if vi > 0 else len(positions) + vi]
+		n = (0.0, 0.0, 0.0)
+		t = (0.0, 0.0)
+		if ni != 0 and normals:
+			n = normals[ni - 1 if ni > 0 else len(normals) + ni]
+		if ti != 0 and texcoords:
+			t = texcoords[ti - 1 if ti > 0 else len(texcoords) + ti]
+		idx = len(vertices_u)
+		vertex_map[key] = idx
+		vertices_u.append(v)
+		normals_u.append(n)
+		uvs_u.append(t)
+		return idx
+
+	with open(obj_path, "rt", encoding="utf8", errors="ignore") as f:
+		for line in f:
+			line = line.strip()
+			if not line or line.startswith("#"):
+				continue
+			parts = line.split()
+			tok = parts[0]
+			if tok == "v" and len(parts) >= 4:
+				x, y, z = float(parts[1]), float(parts[2]), float(parts[3])
+				positions.append((x, y, z))
+			elif tok == "vn" and len(parts) >= 4:
+				x, y, z = float(parts[1]), float(parts[2]), float(parts[3])
+				normals.append((x, y, z))
+			elif tok == "vt" and len(parts) >= 3:
+				u, v = float(parts[1]), float(parts[2])
+				texcoords.append((u, v))
+			elif tok == "f" and len(parts) >= 4:
+				# Support formats: v, v/vt, v//vn, v/vt/vn
+				# Build face as list of unified indices then triangulate via fan
+				face: List[int] = []
+				for p in parts[1:]:
+					if "/" in p:
+						sp = p.split("/")
+						vi = int(sp[0]) if sp[0] else 0
+						ti = int(sp[1]) if len(sp) > 1 and sp[1] else 0
+						ni = int(sp[2]) if len(sp) > 2 and sp[2] else 0
+					else:
+						vi = int(p)
+						ti = 0
+						ni = 0
+					face.append(add_vertex(vi, ti, ni))
+				# triangulate fan: (0,i,i+1)
+				for i in range(1, len(face) - 1):
+					# Reverse winding to match MeshExporter which outputs flipped order
+					indices.extend([face[i + 1], face[i], face[0]])
+
+	return ObjMesh(
+		positions=positions,
+		normals=normals,
+		texcoords=texcoords,
+		vertices=vertices_u,
+		normals_u=normals_u,
+		uvs_u=uvs_u,
+		indices=indices,
+	)
+
+
+def to_unity_convention(mesh: ObjMesh, flip_x: bool = True) -> ObjMesh:
+	"""
+	Convert coordinates to match the exporter convention (which negates X when writing OBJ).
+	"""
+	if not flip_x:
+		return mesh
+
+	def fx3(v):
+		return (-v[0], v[1], v[2])
+
+	mesh.vertices = [fx3(v) for v in mesh.vertices]
+	mesh.normals_u = [fx3(n) for n in mesh.normals_u]
+	return mesh
+
+
+# Optional: Integrate with Unity AOV environment to replace an existing Mesh
+
+def try_replace_mesh_in_assets(assets_path: str, obj_mesh: ObjMesh, target_name: Optional[str] = None, target_path_id: Optional[int] = None, out_dir: Optional[str] = None) -> bool:
+	"""
+	Attempt to load a Unity assets/bundle, find a Mesh by name or path_id, and replace its geometry.
+	This currently supports meshes that use legacy direct arrays (no modern VertexData streams).
+	Returns True if replacement succeeded and was saved.
+	"""
+	try:
+		from Unity\ AOV.environment import Environment  # type: ignore
+		from Unity\ AOV.enums.ClassIDType import ClassIDType  # type: ignore
+		from Unity\ AOV.classes.Mesh import Mesh as UnityMesh  # type: ignore
+	except Exception:
+		# Fallback import path if the package name differs (e.g., UnityPy_AOV)
+		try:
+			from Unity_AOV.environment import Environment  # type: ignore
+			from Unity_AOV.enums.ClassIDType import ClassIDType  # type: ignore
+			from Unity_AOV.classes.Mesh import Mesh as UnityMesh  # type: ignore
+		except Exception:
+			return False
+
+	env = Environment(assets_path)
+	candidate = None
+	for obj in env.objects:
+		if obj.type.name != "Mesh":
+			continue
+		if target_path_id is not None and obj.path_id == target_path_id:
+			candidate = obj
+			break
+		if target_name and obj.container and os.path.basename(obj.container).startswith(target_name):
+			candidate = obj
+			break
+
+	if not candidate:
+		return False
+
+	m = candidate.read()
+	# Heuristic: if modern vertex streams are present, abort (not implemented here)
+	if hasattr(m, "m_VertexData") and getattr(m.m_VertexData, "m_VertexCount", 0) > 0:
+		return False
+
+	# Populate legacy arrays
+	m.m_VertexCount = len(obj_mesh.vertices)
+	m.m_Vertices = [c for v in obj_mesh.vertices for c in (v[0], v[1], v[2])]
+	m.m_Normals = [c for n in obj_mesh.normals_u for c in (n[0], n[1], n[2])]
+	m.m_UV0 = [c for t in obj_mesh.uvs_u for c in (t[0], t[1])]
+	# Index data
+	m.m_Use16BitIndices = max(obj_mesh.indices) < 65535 if obj_mesh.indices else True
+	# Many engines store index buffer as m_IndexBuffer; also retain m_Indices to keep exporter compatibility
+	m.m_Indices = list(obj_mesh.indices)
+	m.m_IndexBuffer = list(obj_mesh.indices)
+
+	# Single SubMesh covering all indices
+	# If the SubMesh type exists, create a lightweight instance with required fields
+	try:
+		from Unity\ AOV.classes.Mesh import SubMesh  # type: ignore
+		sm = object.__new__(SubMesh)
+		sm.firstByte = 0
+		sm.indexCount = len(obj_mesh.indices)
+		sm.topology = 0  # assume triangles
+		sm.triangleCount = len(obj_mesh.indices) // 3
+		sm.baseVertex = 0
+		sm.firstVertex = 0
+		sm.vertexCount = len(obj_mesh.vertices)
+		sm.localAABB = getattr(m, "m_LocalAABB", None)
+		m.m_SubMeshes = [sm]
+	except Exception:
+		# Fallback: try to assign a typetree-like dict
+		m.m_SubMeshes = [{
+			"firstByte": 0,
+			"indexCount": len(obj_mesh.indices),
+			"topology": 0,
+			"triangleCount": len(obj_mesh.indices) // 3,
+			"baseVertex": 0,
+			"firstVertex": 0,
+			"vertexCount": len(obj_mesh.vertices),
+		}]
+
+	# Save back into the asset and write files
+	m.save()
+	if out_dir:
+		env.out_path = out_dir
+	env.save(pack="none")
+	return True
+
+
+def main(argv: List[str]) -> int:
+	import argparse
+	p = argparse.ArgumentParser(description="OBJ Importer for Unity AOV tools")
+	p.add_argument("obj", help="Path to .obj file to import")
+	p.add_argument("--to-json", dest="json_out", help="Output parsed mesh as JSON to this path")
+	p.add_argument("--assets", dest="assets", help="Path to a Unity assets/bundle file to modify")
+	p.add_argument("--mesh-name", dest="mesh_name", help="Target Mesh name prefix (matches container basename)")
+	p.add_argument("--mesh-path-id", dest="mesh_path_id", type=int, help="Target Mesh path_id")
+	p.add_argument("--out", dest="out_dir", help="Output directory for modified assets (default ./output)")
+	p.add_argument("--no-flip-x", dest="no_flip_x", action="store_true", help="Do not flip X axis (by default X is negated)")
+	args = p.parse_args(argv)
+
+	if not os.path.exists(args.obj):
+		print(f"OBJ not found: {args.obj}")
+		return 2
+
+	mesh = parse_obj(args.obj)
+	mesh = to_unity_convention(mesh, flip_x=(not args.no_flip_x))
+
+	if args.json_out:
+		payload = {
+			"vertices": [c for v in mesh.vertices for c in (v[0], v[1], v[2])],
+			"normals": [c for n in mesh.normals_u for c in (n[0], n[1], n[2])],
+			"uv0": [c for t in mesh.uvs_u for c in (t[0], t[1])],
+			"indices": mesh.indices,
+		}
+		os.makedirs(os.path.dirname(os.path.abspath(args.json_out)) or ".", exist_ok=True)
+		with open(args.json_out, "wt", encoding="utf8") as f:
+			json.dump(payload, f)
+		print(f"Wrote JSON: {args.json_out}")
+
+	if args.assets:
+		ok = try_replace_mesh_in_assets(
+			assets_path=args.assets,
+			obj_mesh=mesh,
+			target_name=args.mesh_name,
+			target_path_id=args.mesh_path_id,
+			out_dir=args.out_dir or os.path.join(os.getcwd(), "output"),
+		)
+		if not ok:
+			print("Mesh replacement not supported for this asset or target not found.")
+			return 3
+		print("Mesh replaced and assets saved.")
+
+	return 0
+
+
+if __name__ == "__main__":
+	sys.exit(main(sys.argv[1:]))

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -523,6 +523,26 @@ def try_replace_mesh_in_assets(assets_path: str, obj_mesh: ObjMesh, target_name:
 								pv.m_NumItems = 0
 					# ensure index buffer for legacy triangle build
 					m.m_IndexBuffer = list(obj_mesh.indices)
+					# ensure at least one SubMesh object for exporters
+					try:
+						from importlib import import_module
+						MeshMod = import_module(f"{m.__class__.__module__}")
+						SubMesh = getattr(MeshMod, 'SubMesh')
+						if not getattr(m, 'm_SubMeshes', None):
+							sm = object.__new__(SubMesh)
+							sm.firstByte = 0
+							sm.indexCount = len(obj_mesh.indices)
+							sm.topology = 0
+							sm.baseVertex = 0
+							sm.firstVertex = 0
+							sm.vertexCount = len(obj_mesh.vertices)
+							sm.localAABB = getattr(m, 'm_LocalAABB', None)
+							m.m_SubMeshes = [sm]
+					except Exception:
+						if not getattr(m, 'm_SubMeshes', None):
+							class _SM: pass
+							sm = _SM(); sm.firstByte=0; sm.indexCount=len(obj_mesh.indices); sm.topology=0; sm.baseVertex=0; sm.firstVertex=0; sm.vertexCount=len(obj_mesh.vertices); sm.localAABB=getattr(m,'m_LocalAABB',None)
+							m.m_SubMeshes = [sm]
 				else:
 					try:
 						ver = getattr(m, 'version', (2022,3,5))
@@ -649,6 +669,26 @@ def try_replace_mesh_in_assets(assets_path: str, obj_mesh: ObjMesh, target_name:
 						pv.m_NumItems = 0
 			# ensure index buffer for legacy triangle build
 			m.m_IndexBuffer = list(obj_mesh.indices)
+			# ensure at least one SubMesh object for exporters
+			try:
+				from importlib import import_module
+				MeshMod = import_module(f"{m.__class__.__module__}")
+				SubMesh = getattr(MeshMod, 'SubMesh')
+				if not getattr(m, 'm_SubMeshes', None):
+					sm = object.__new__(SubMesh)
+					sm.firstByte = 0
+					sm.indexCount = len(obj_mesh.indices)
+					sm.topology = 0
+					sm.baseVertex = 0
+					sm.firstVertex = 0
+					sm.vertexCount = len(obj_mesh.vertices)
+					sm.localAABB = getattr(m, 'm_LocalAABB', None)
+					m.m_SubMeshes = [sm]
+			except Exception:
+				if not getattr(m, 'm_SubMeshes', None):
+					class _SM: pass
+					sm = _SM(); sm.firstByte=0; sm.indexCount=len(obj_mesh.indices); sm.topology=0; sm.baseVertex=0; sm.firstVertex=0; sm.vertexCount=len(obj_mesh.vertices); sm.localAABB=getattr(m,'m_LocalAABB',None)
+					m.m_SubMeshes = [sm]
 		else:
 			try:
 				ver = getattr(m, 'version', (2022,3,5))

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -454,6 +454,8 @@ def try_replace_mesh_in_assets(assets_path: str, obj_mesh: ObjMesh, target_name:
 					ver = getattr(m, 'version', (2022,3,5))
 					if ver >= (2019,):
 						_rebuild_vertex_data_modern(m, obj_mesh.vertices, obj_mesh.normals_u, obj_mesh.uvs_u, debug)
+						# Provide index buffer for triangle build
+						m.m_IndexBuffer = list(obj_mesh.indices)
 				except Exception as e:
 					if debug:
 						print(f"[DEBUG] VertexData rebuild skipped: {e}")
@@ -542,6 +544,8 @@ def try_replace_mesh_in_assets(assets_path: str, obj_mesh: ObjMesh, target_name:
 			ver = getattr(m, 'version', (2022,3,5))
 			if ver >= (2019,):
 				_rebuild_vertex_data_modern(m, obj_mesh.vertices, obj_mesh.normals_u, obj_mesh.uvs_u, debug)
+				# Provide index buffer for triangle build
+				m.m_IndexBuffer = list(obj_mesh.indices)
 		except Exception as e:
 			if debug:
 				print(f"[DEBUG] VertexData rebuild skipped: {e}")

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -521,6 +521,8 @@ def try_replace_mesh_in_assets(assets_path: str, obj_mesh: ObjMesh, target_name:
 							pv = getattr(cm, fld, None)
 							if pv is not None and hasattr(pv, 'm_NumItems'):
 								pv.m_NumItems = 0
+					# ensure index buffer for legacy triangle build
+					m.m_IndexBuffer = list(obj_mesh.indices)
 				else:
 					try:
 						ver = getattr(m, 'version', (2022,3,5))
@@ -636,6 +638,8 @@ def try_replace_mesh_in_assets(assets_path: str, obj_mesh: ObjMesh, target_name:
 					pv = getattr(cm, fld, None)
 					if pv is not None and hasattr(pv, 'm_NumItems'):
 						pv.m_NumItems = 0
+			# ensure index buffer for legacy triangle build
+			m.m_IndexBuffer = list(obj_mesh.indices)
 		else:
 			try:
 				ver = getattr(m, 'version', (2022,3,5))

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -319,6 +319,11 @@ def _update_submesh_and_flags(m, num_vertices: int, num_indices: int):
 		# Index format for >=2017.3
 		if hasattr(m, "m_IndexFormat"):
 			m.m_IndexFormat = 0 if num_indices == 0 or (num_vertices <= 65535) else 1
+		# Compression flags as safe defaults
+		if hasattr(m, "m_MeshCompression"):
+			m.m_MeshCompression = 0
+		if hasattr(m, "m_StreamCompression"):
+			m.m_StreamCompression = 0
 	except Exception:
 		pass
 

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -272,7 +272,8 @@ def try_replace_mesh_in_assets(assets_path: str, obj_mesh: ObjMesh, target_name:
 				m.m_UV0 = [c for t in obj_mesh.uvs_u for c in (t[0], t[1])]
 				m.m_Use16BitIndices = max(obj_mesh.indices) < 65535 if obj_mesh.indices else True
 				m.m_Indices = list(obj_mesh.indices)
-				m.m_IndexBuffer = list(obj_mesh.indices)
+				# Avoid assigning m_IndexBuffer directly for legacy formats
+				# writer will serialize from m_Indices/m_Use16BitIndices
 				# Update existing submeshes if any
 				try:
 					submeshes = getattr(m, "m_SubMeshes", None)
@@ -336,7 +337,7 @@ def try_replace_mesh_in_assets(assets_path: str, obj_mesh: ObjMesh, target_name:
 		m.m_UV0 = [c for t in obj_mesh.uvs_u for c in (t[0], t[1])]
 		m.m_Use16BitIndices = max(obj_mesh.indices) < 65535 if obj_mesh.indices else True
 		m.m_Indices = list(obj_mesh.indices)
-		m.m_IndexBuffer = list(obj_mesh.indices)
+		# Avoid assigning m_IndexBuffer directly for legacy formats
 		# Update existing submeshes if any
 		try:
 			submeshes = getattr(m, "m_SubMeshes", None)

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -356,13 +356,31 @@ def _rebuild_vertex_data_modern(m, verts: List[Tuple[float, float, float]], norm
 			vd = object.__new__(VertexDataCls)
 		m.m_VertexData = vd
 		vd.m_VertexCount = N
+		# Optionally set m_CurrentChannels bitmask if field exists (mainly <2018, safe otherwise)
+		if not hasattr(vd, 'm_CurrentChannels'):
+			try:
+				vd.m_CurrentChannels = 0
+			except Exception:
+				pass
 		# Build channels list with correct indices (0=pos,1=normal,2=tangent,3=color,4=uv0)
-		ch_pos = object.__new__(ChannelInfo); ch_pos.stream = 0; ch_pos.offset = 0; ch_pos.format = 0; ch_pos.dimension = 3
-		ch_nrm = object.__new__(ChannelInfo); ch_nrm.stream = 0; ch_nrm.offset = 12; ch_nrm.format = 0; ch_nrm.dimension = 3
-		ch_tan = object.__new__(ChannelInfo); ch_tan.stream = 0; ch_tan.offset = 0; ch_tan.format = 0; ch_tan.dimension = 0
-		ch_col = object.__new__(ChannelInfo); ch_col.stream = 0; ch_col.offset = 0; ch_col.format = 0; ch_col.dimension = 0
-		ch_uv0 = object.__new__(ChannelInfo); ch_uv0.stream = 0; ch_uv0.offset = 24; ch_uv0.format = 0; ch_uv0.dimension = 2
-		vd.m_Channels = [ch_pos, ch_nrm, ch_tan, ch_col, ch_uv0]
+		channels = []
+		for i in range(12):
+			ci = object.__new__(ChannelInfo)
+			ci.stream = 0
+			ci.offset = 0
+			ci.format = 0
+			ci.dimension = 0
+			channels.append(ci)
+		# pos
+		channels[0].offset = 0
+		channels[0].dimension = 3
+		# normal
+		channels[1].offset = 12
+		channels[1].dimension = 3
+		# uv0 at index 4
+		channels[4].offset = 24
+		channels[4].dimension = 2
+		vd.m_Channels = channels
 		vd.m_Streams = {0: object()}
 		vd.m_DataSize = bytes(buf)
 		# Clear compressed mesh to avoid overrides

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -375,6 +375,15 @@ def _rebuild_vertex_data_modern(m, verts: List[Tuple[float, float, float]], norm
 						pv.m_NumItems = 0
 				except Exception:
 					pass
+		# Disable external stream to force inline vertex data
+		try:
+			sd = getattr(m, 'm_StreamData', None)
+			if sd is not None:
+				sd.path = ""
+				sd.offset = 0
+				sd.size = 0
+		except Exception:
+			pass
 		# Also set index format
 		if hasattr(m, 'm_IndexFormat'):
 			m.m_IndexFormat = 0 if N <= 65535 else 1

--- a/Unity AOV/tools/obj_importer.py
+++ b/Unity AOV/tools/obj_importer.py
@@ -356,11 +356,13 @@ def _rebuild_vertex_data_modern(m, verts: List[Tuple[float, float, float]], norm
 			vd = object.__new__(VertexDataCls)
 		m.m_VertexData = vd
 		vd.m_VertexCount = N
-		# Build channels list
+		# Build channels list with correct indices (0=pos,1=normal,2=tangent,3=color,4=uv0)
 		ch_pos = object.__new__(ChannelInfo); ch_pos.stream = 0; ch_pos.offset = 0; ch_pos.format = 0; ch_pos.dimension = 3
 		ch_nrm = object.__new__(ChannelInfo); ch_nrm.stream = 0; ch_nrm.offset = 12; ch_nrm.format = 0; ch_nrm.dimension = 3
+		ch_tan = object.__new__(ChannelInfo); ch_tan.stream = 0; ch_tan.offset = 0; ch_tan.format = 0; ch_tan.dimension = 0
+		ch_col = object.__new__(ChannelInfo); ch_col.stream = 0; ch_col.offset = 0; ch_col.format = 0; ch_col.dimension = 0
 		ch_uv0 = object.__new__(ChannelInfo); ch_uv0.stream = 0; ch_uv0.offset = 24; ch_uv0.format = 0; ch_uv0.dimension = 2
-		vd.m_Channels = [ch_pos, ch_nrm, ch_uv0]
+		vd.m_Channels = [ch_pos, ch_nrm, ch_tan, ch_col, ch_uv0]
 		vd.m_Streams = {0: object()}
 		vd.m_DataSize = bytes(buf)
 		# Clear compressed mesh to avoid overrides


### PR DESCRIPTION
Add a Python tool (`obj_importer.py`) to parse OBJ files and optionally replace legacy Mesh assets in Unity bundles.

The tool supports parsing OBJ geometry (v/vt/vn/f) and can replace `Mesh` objects in Unity assets/bundles that use direct vertex/normal/UV arrays (legacy format), but not modern `m_VertexData` streams. It also provides an option to export parsed mesh data to JSON.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3609902-0142-47e3-959b-7daca580410a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3609902-0142-47e3-959b-7daca580410a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

